### PR TITLE
Fix: remember last used deployment URL in Deploy wizard

### DIFF
--- a/eclipse-plugin-studio/src/com/twinsoft/convertigo/eclipse/wizards/deploy/ProjectDeployOptionsWizardPage.java
+++ b/eclipse-plugin-studio/src/com/twinsoft/convertigo/eclipse/wizards/deploy/ProjectDeployOptionsWizardPage.java
@@ -21,66 +21,75 @@ package com.twinsoft.convertigo.eclipse.wizards.deploy;
 
 import java.util.HashMap;
 
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 
+import com.twinsoft.convertigo.eclipse.ConvertigoPlugin;
+
 class ProjectDeployOptionsWizardPage extends WizardPage {
+	private static final String PREF_LAST_DEPLOY_URL = "lastDeployUrl";
+
 	private HashMap<String, Object> data = null;
-	
 	private ProjectDeployOptionsComposite composite = null;
-	
+
 	ProjectDeployOptionsWizardPage() {
 		super("ProjectDeployOptionsWizardPage", "Deployment options", null);
 		this.data = new HashMap<String, Object>();
 		this.setPageComplete(false);
 	}
-	
+
 	@Override
 	public void createControl(Composite parent) {
 		composite = new ProjectDeployOptionsComposite(this, parent, SWT.NONE);
 		composite.setOkButton(null);
 		setControl(composite);
+
+		// Restore last used deployment URL
+		IPreferenceStore store = ConvertigoPlugin.getDefault().getPreferenceStore();
+		String lastUrl = store.getString(PREF_LAST_DEPLOY_URL);
+		if (lastUrl != null && !lastUrl.isEmpty()) {
+			composite.convertigoServer.setText(lastUrl);
+		}
 	}
 
 	private HashMap<String, Object> getData() {
 		if (composite != null) {
 			String convertigoServer = composite.convertigoServer.getText();
-			//if ((convertigoServer == null) || (convertigoServer.equals(""))) return;
-			
 			String convertigoUserName = composite.convertigoAdmin.getText();
-			if (convertigoUserName == null) convertigoUserName = "";
-	
 			String convertigoUserPassword = composite.convertigoPassword.getText();
+
+			if (convertigoUserName == null) convertigoUserName = "";
 			if (convertigoUserPassword == null) convertigoUserPassword = "";
-			
+
 			boolean isHttps = composite.checkBox.getSelection();
 			boolean trustAllCertificates = composite.checkTrustAllCertificates.getSelection();
 			boolean bAssembleXsl = composite.assembleXsl.getSelection();
-			
+
 			data.put("convertigoServer", convertigoServer);
 			data.put("convertigoUserName", convertigoUserName);
 			data.put("convertigoUserPassword", convertigoUserPassword);
 			data.put("isHttps", Boolean.valueOf(isHttps));
 			data.put("trustAllCertificates", Boolean.valueOf(trustAllCertificates));
 			data.put("bAssembleXsl", Boolean.valueOf(bAssembleXsl));
+
+			// Save last used deployment URL
+			IPreferenceStore store = ConvertigoPlugin.getDefault().getPreferenceStore();
+			store.setValue(PREF_LAST_DEPLOY_URL, convertigoServer);
 		}
 		return data;
 	}
-	
-	@Override
-	public void setPageComplete(boolean complete) {
-		super.setPageComplete(complete);
-	}
-	
+
 	@Override
 	public void setVisible(boolean visible) {
 		super.setVisible(visible);
 		if (!visible && isControlCreated() && !isCurrentPage()) {
 			try {
 				if (getContainer().getCurrentPage().equals(getWizard().getNextPage(this))) {
-					((ProjectDeployResultWizardPage)getWizard().getNextPage(this)).setOptionsData(getData());
+					((ProjectDeployResultWizardPage) getWizard().getNextPage(this))
+							.setOptionsData(getData());
 				}
 			} catch (Exception e) {
 				e.printStackTrace();
@@ -101,5 +110,6 @@ class ProjectDeployOptionsWizardPage extends WizardPage {
 	@Override
 	public boolean isPageComplete() {
 		return super.isPageComplete();
-	}	
+	}
 }
+


### PR DESCRIPTION
## Summary
Fixes a regression where the Deploy wizard no longer remembers the previously used deployment URL and always defaults to the first entry in the list.

## Changes
- Persist and restore the last used deployment URL in the Deploy wizard
- Ensure the previously selected URL is pre-selected when reopening the wizard
- Maintain existing behavior for users deploying for the first time
- No functional changes outside the Deploy wizard flow

## Testing
- Opened the Deploy wizard and selected a non-default deployment URL
- Completed a deployment
- Reopened the Deploy wizard
- Verified that the previously used deployment URL is automatically pre-selected
- Confirmed no impact on deployment execution

## Notes
This fix restores behavior present in earlier versions and improves usability by reducing accidental deployments to unintended servers.  
The change is intentionally minimal and limited to wizard state handling to keep it safe and easy to review.
